### PR TITLE
feat: add HTML wrapper around Credit label

### DIFF
--- a/newspack-image-credits.php
+++ b/newspack-image-credits.php
@@ -94,7 +94,11 @@ class Newspack_Image_Credits {
 			$credit = '<a href="' . $credit_info['credit_url'] . '" target="_blank">' . $credit . '</a>';
 		}
 
-		$credit = '<span class="image-credit">' . sprintf( __( 'Credit: %s', 'newspack-image-credits' ), $credit ) . '</span>';
+		$credit = sprintf(
+			'<span class="image-credit"><span class="credit-label-wrapper">%1$s</span> %2$s</span>',
+			esc_html__( 'Credit:', 'newspack-image-credits' ),
+			$credit
+		);
 
 		return wp_kses_post( $credit );
 	}


### PR DESCRIPTION
This PR adds an HTML wrapper around the word 'Credit:', to allow it to be hidden.

This is potentially another approach/complementary approach to #3; one plus to using CSS to hide the label is that we can hide it in a way that it's still accessible to screen readers. On the flip-side, I'm sure there's still a need to change this text, so that's probably still a required piece, too, so that might be a better single approach - I'm open to feedback on this! 