### PR TITLE
Adds CSS class to image credit

### DIFF
--- a/newspack-image-credits.php
+++ b/newspack-image-credits.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack Image Credits
  * Description: Add photo credit info to images. A modernization of Navis Media Credit.
- * Version: 1.0.1
+ * Version: 1.0.2
  * Author: Automattic, INN Labs, Project Argo
  * Author URI: https://newspack.blog/
  * License: GPL2
@@ -94,7 +94,7 @@ class Newspack_Image_Credits {
 			$credit = '<a href="' . $credit_info['credit_url'] . '" target="_blank">' . $credit . '</a>';
 		}
 
-		$credit = '<span class="image-credit">' . sprintf( __( 'Credit: %s', 'newspack-image-credits' ), $credit ) . '</span>';
+		$credit = '<span class="image-credit">' . sprintf( __( '<span class="credit-prefix">Credit: </span>%s', 'newspack-image-credits' ), $credit ) . '</span>';
 
 		return wp_kses_post( $credit );
 	}


### PR DESCRIPTION
By wrapping the "Credit: " text in a class (`credit-prefix`), customers can target it with custom CSS separately from the credit itself.

**Test of current behavior on local MAMP installation** — "Credit: Hello World"

![1-default-behavior](https://user-images.githubusercontent.com/12199101/118315356-47625a00-b4aa-11eb-81c8-33fc6e189f2e.jpg)

**Class added to line 97 of plugin, no other changes** — "Credit: Hello World"

![2-modified-plugin](https://user-images.githubusercontent.com/12199101/118315391-51845880-b4aa-11eb-96cd-7b71a1e41408.jpg)

**Custom CSS `.credit-prefix {display:none;}` applied** — "Hello World"

![3-custom-css](https://user-images.githubusercontent.com/12199101/118315478-6b25a000-b4aa-11eb-8e02-42b244da27ea.jpg)
