### PR TITLE
feat: show credits on jetpack slideshows as well

### DIFF
--- a/newspack-image-credits.php
+++ b/newspack-image-credits.php
@@ -229,10 +229,20 @@ class Newspack_Image_Credits {
 
 			$index        = -1;
 			$block_output = preg_replace_callback(
-				'/<\/figcaption>/',
+				'/<figure>(.*?)<\/figure>/',
 				function( $matches ) use ( &$credit_strings, &$index ) {
-					$index ++;
-					return ' ' . $credit_strings[ $index ] . '</figcaption>';
+					$index       ++;
+					$replacement = $matches[0];
+
+					if ( strpos( $replacement, '</figcaption>' ) ) {
+						// If an image caption exists, add the credit to it.
+						$replacement = str_replace( '</figcaption>', ' ' . $credit_strings[ $index ] . '</figcaption>', $replacement );
+					} else {
+						// If an image caption doesn't exist, make the credit the caption.
+						$replacement = str_replace( '</figure>', '<figcaption class="wp-block-jetpack-slideshow_caption gallery-caption">' . $credit_strings[ $index ] . '</figcaption></figure>', $replacement );
+					}
+
+					return $replacement;
 				},
 				$block_output
 			);


### PR DESCRIPTION
Show image credits in Jetpack Slideshow blocks as well.

To test:

1. Upload a bunch of images, some with both captions and credits, some with captions only, some with credits only, and others with neither.
2. In a post, create a Jetpack Slideshow block and add the images.
3. Verify that on the front-end, the credits are appended to the captions.
4. Test with both AMP and non-AMP.